### PR TITLE
Easy functions

### DIFF
--- a/DijkstraMetagraphTestbed.ipynb
+++ b/DijkstraMetagraphTestbed.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load the ZFSearch module:"
+    "## Import the zero_forcing_set function:"
    ]
   },
   {
@@ -15,15 +15,14 @@
    },
    "outputs": [],
    "source": [
-    "from zeroforcing.metagraph import ZFSearchMetagraph"
+    "from zeroforcing.metagraph import zero_forcing_set"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pick a graph, any graph!\n",
-    "## Initialize a test graph and the associated ZFSearchMetagraph"
+    "## Pick a graph, any graph!\n"
    ]
   },
   {
@@ -40,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Construct the metagraph and then find the zero forcing set of H:"
+    "## Find the zero forcing set of H:"
    ]
   },
   {
@@ -51,15 +50,11 @@
    },
    "outputs": [],
    "source": [
-    "metaGraph = ZFSearchMetagraph(H)\n",
     "print(\"This graph has\", H.num_verts(), \"vertices\")\n",
     "\n",
-    "all_unfilled = metaGraph.to_relabeled_metavertex([])\n",
-    "all_filled = metaGraph.to_relabeled_metavertex(H.vertices(sort=False))\n",
-    "\n",
-    "%prun output = metaGraph.dijkstra(all_unfilled, all_filled)\n",
-    "print(\"Zero forcing number:\", len(output))\n",
-    "print(\"Zero forcing set:\", output)"
+    "%prun zf_set = zero_forcing_set(H)\n",
+    "print(\"Zero forcing number:\", len(zf_set))\n",
+    "print(\"Zero forcing set:\", zf_set)"
    ]
   }
  ],

--- a/DijkstraMetagraphTestbed.ipynb
+++ b/DijkstraMetagraphTestbed.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pick a graph, any graph!\n",
+    "## Pick a graph, any graph!\n",
     "## Initialize a test graph and the associated ZFSearchMetagraph"
    ]
   },
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Construct the metagraph and then find the zero forcing set of G:"
+    "## Construct the metagraph and then find the zero forcing set of H:"
    ]
   },
   {

--- a/zeroforcing/metagraph.pyx
+++ b/zeroforcing/metagraph.pyx
@@ -32,6 +32,17 @@ from cpython.mem cimport (
 from zeroforcing.fastqueue cimport FastQueueForBFS
 
 
+def zero_forcing_set(sage_graph):
+    cdef:
+        ZFSearchMetagraph metagraph = ZFSearchMetagraph(sage_graph)
+        frozenset start = frozenset()
+        frozenset end = frozenset(metagraph.to_relabeled_metavertex(sage_graph.vertices(sort=False)))
+
+    return metagraph.dijkstra(start, end)
+
+def zero_forcing_number(sage_graph):
+    return len(zero_forcing_set(sage_graph))
+
 cdef class ExtendClosureBitsets:
     def __cinit__(self, size_t num_vertices):
         # TODO: Figure out how to have less verbosity here?


### PR DESCRIPTION
Added functions to do the busywork of constructing the metagraph and
running `dijkstra()` on it. Updated DijkstraMetagraphTestbed to use
`zero_forcing_set()`.

Did not create tests for these functions as they are fairly simple, and would just ~2x the time it takes to test for no reason. It would also be hard to add profiling if we made the tests use these instead of manually setting everything up. We only want to profile the most important part -- `dijkstra()`.

Also, we should probably tweak the module scheme. I'm not too sure where these should go, perhaps the base module (`zeroforcing`)? They seem kind of out of place in `zeroforcing.metagraph`.