### PR TITLE
Verify compatible graph type

### DIFF
--- a/src/zftools/metagraph.pyx
+++ b/src/zftools/metagraph.pyx
@@ -49,13 +49,12 @@ def zero_forcing_set(sage_graph):
     try:
         metagraph = ZFSearchMetagraph(sage_graph)
     except GraphIsDirectedError:
-        # This is where we will instantiate a metagraph
-        # for directed forcing
-        print("This is a directed graph.  Currently, directed graph zero forcing is not implemented.")
+        # This is where we will instantiate a metagraph for directed forcing
+        raise NotImplementedError("This is a directed graph.  Currently, directed graph zero forcing is not implemented.")
     except GraphAllowsLoopsError:
-        # This is where we will instantiate a metagraph for
-        # an undirected graph with loops
-        print("This graph allows loops.  Currently, looped zero forcing is not implemented.")
+        # This is where we will instantiate a metagraph for (undirected)
+        # looped forcing
+        raise NotImplementedError("This graph allows loops.  Currently, looped zero forcing is not implemented.")
     else:
         start = frozenset()
         end = frozenset(metagraph.to_relabeled_metavertex(sage_graph.vertices(sort=False)))

--- a/src/zftools/metagraph.pyx
+++ b/src/zftools/metagraph.pyx
@@ -31,6 +31,13 @@ from cpython.mem cimport (
 from zftools.fastqueue cimport FastQueueForBFS
 
 
+def verify_graph_is_compatible(sage_graph):
+    if sage_graph.is_directed():
+        raise ValueError("This is a directed graph.  Currently, directed graph zero forcing is not implemented.")
+    elif sage_graph.has_loops():
+        raise ValueError("This graph has loops.  Currently, looped zero forcing is not implemented.")
+
+
 def zero_forcing_set(sage_graph):
     cdef:
         ZFSearchMetagraph metagraph = ZFSearchMetagraph(sage_graph)
@@ -38,7 +45,8 @@ def zero_forcing_set(sage_graph):
         frozenset end = frozenset(
                 metagraph.to_relabeled_metavertex(sage_graph.vertices(sort=False))
                 )
-
+    
+    verify_graph_is_compatible(sage_graph)
     return metagraph.dijkstra(start, end)
 
 

--- a/src/zftools/metagraph.pyx
+++ b/src/zftools/metagraph.pyx
@@ -42,23 +42,13 @@ class GraphAllowsLoopsError(NotImplementedError):
 
 def zero_forcing_set(sage_graph):
     cdef:
-        ZFSearchMetagraph metagraph
-        frozenset start
-        frozenset end
-    
-    try:
-        metagraph = ZFSearchMetagraph(sage_graph)
-    except GraphIsDirectedError:
-        # This is where we will instantiate a metagraph for directed forcing
-        raise NotImplementedError("This is a directed graph.  Currently, directed graph zero forcing is not implemented.")
-    except GraphAllowsLoopsError:
-        # This is where we will instantiate a metagraph for (undirected)
-        # looped forcing
-        raise NotImplementedError("This graph allows loops.  Currently, looped zero forcing is not implemented.")
-    else:
-        start = frozenset()
-        end = frozenset(metagraph.to_relabeled_metavertex(sage_graph.vertices(sort=False)))
-        return metagraph.dijkstra(start, end)
+        ZFSearchMetagraph metagraph = ZFSearchMetagraph(sage_graph)
+        frozenset start = frozenset()
+        frozenset end = frozenset(
+                metagraph.to_relabeled_metavertex(sage_graph.vertices(sort=False))
+                )
+
+    return metagraph.dijkstra(start, end)
 
 
 def zero_forcing_number(sage_graph):
@@ -121,9 +111,9 @@ cdef class ZFSearchMetagraph:
 
     def __init__(self, graph_for_zero_forcing not None):
         if graph_for_zero_forcing.is_directed():
-            raise GraphIsDirectedError
+            raise GraphIsDirectedError("This is a directed graph. Currently, directed graph zero forcing is not implemented.")
         elif graph_for_zero_forcing.allows_loops():
-            raise GraphAllowsLoopsError
+            raise GraphAllowsLoopsError("This graph allows loops. Currently, looped zero forcing is not implemented.")
 
         graph_copy = graph_for_zero_forcing.copy(immutable=False)
         self.orig_to_relabeled_verts = graph_copy.relabel(inplace=True, return_map=True)


### PR DESCRIPTION
Added function `verify_graph_is_compatible()` to make sure graph is simple (i.e., has no loops and is not a directed graph).  This function may disappear once support for these types of graphs is added, at which time new code will be required to apply search on the correct type of metagraph (meaning the subclass of metagraph corresponding to the type of primal graph that is passed in).